### PR TITLE
SSL対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,20 +7,25 @@ RUN useradd --create-home --comment "Account for running Confluence" --shell /bi
 RUN apt-get install -y wget
 RUN mkdir -p /opt/atlassian
 
-RUN wget https://www.atlassian.com/software/confluence/downloads/binary/atlassian-confluence-5.9.10.tar.gz \
-    && tar -zxvf atlassian-confluence-5.9.10.tar.gz -C /opt/atlassian \
-    && rm atlassian-confluence-5.9.10.tar.gz \
-    && chown -R confadmin /opt/atlassian/atlassian-confluence-5.9.10/ \
-    && chgrp -R confadmin /opt/atlassian/atlassian-confluence-5.9.10/
+ENV CONF_VERSION 5.9.10
 
-RUN echo -e "\nconfluence.home=/var/atlassian/application-data/confluence" >> /opt/atlassian/atlassian-confluence-5.9.10/confluence/WEB-INF/classes/confluence-init.properties
+RUN wget https://www.atlassian.com/software/confluence/downloads/binary/atlassian-confluence-${CONF_VERSION}.tar.gz \
+    && tar -zxvf atlassian-confluence-${CONF_VERSION}.tar.gz -C /opt/atlassian \
+    && rm atlassian-confluence-${CONF_VERSION}.tar.gz \
+    && chown -R confadmin /opt/atlassian/atlassian-confluence-${CONF_VERSION}/ \
+    && chgrp -R confadmin /opt/atlassian/atlassian-confluence-${CONF_VERSION}/
+
+RUN echo -e "\nconfluence.home=/var/atlassian/application-data/confluence" >> /opt/atlassian/atlassian-confluence-${CONF_VERSION}/confluence/WEB-INF/classes/confluence-init.properties
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 ENV CONF_USER confadmin
 
 # bug fix ... tofu
-RUN wget https://maven.atlassian.com/service/local/repositories/atlassian-public/content/com/atlassian/plugins/document-conversion-library/1.2.12/document-conversion-library-1.2.12.jar -O /opt/atlassian/atlassian-confluence-5.9.10/confluence/WEB-INF/atlassian-bundled-plugins/document-conversion-library-1.2.12.jar
-RUN rm /opt/atlassian/atlassian-confluence-5.9.10/confluence/WEB-INF/atlassian-bundled-plugins/document-conversion-library-1.2.14.jar
-RUN sed -i -e "43a CATALINA_OPTS=\"-Dconfluence.document.conversion.fontpath=/var/atlassian/application-data/confluence/fonts \${CATALINA_OPTS}\"" /opt/atlassian/atlassian-confluence-5.9.10/bin/setenv.sh
+RUN wget https://maven.atlassian.com/service/local/repositories/atlassian-public/content/com/atlassian/plugins/document-conversion-library/1.2.12/document-conversion-library-1.2.12.jar -O /opt/atlassian/atlassian-confluence-${CONF_VERSION}/confluence/WEB-INF/atlassian-bundled-plugins/document-conversion-library-1.2.12.jar
+RUN rm /opt/atlassian/atlassian-confluence-${CONF_VERSION}/confluence/WEB-INF/atlassian-bundled-plugins/document-conversion-library-1.2.14.jar
+RUN sed -i -e "43a CATALINA_OPTS=\"-Dconfluence.document.conversion.fontpath=/var/atlassian/application-data/confluence/fonts \${CATALINA_OPTS}\"" /opt/atlassian/atlassian-confluence-${CONF_VERSION}/bin/setenv.sh
 
-ENTRYPOINT ["/opt/atlassian/atlassian-confluence-5.9.10/bin/start-confluence.sh", "-fg"]
+COPY entrypoint.sh /sbin/entrypoint.sh
+RUN chmod 755 /sbin/entrypoint.sh
+
+ENTRYPOINT ["/sbin/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# 環境変数 $SSL がTRUEのときはserver.xmlを編集し、SSL接続待ち受けコネクタを追加する
+# ただし、各SSLパラメータが定義されていないときはコンテナを停止させる
+# 既にSSL接続待ち受けコネクタが追加されているときはserver.xmlを編集せずそのままにする
+if [ "${SSL}" = "TRUE" ]; then
+ isMod=$(grep "SSLCONNECTOR_INSERT" -c /opt/atlassian/atlassian-confluence-${CONF_VERSION}/conf/server.xml)
+
+ if [ "${KEYSTORE_PATH}" = "" ]; then
+  echo "UNDEFINED KEYSTORE_PATH"
+  exit
+ elif [ "${KEYSTORE_PASS}" = "" ]; then
+  echo "UNDEFINED KEYSTORE_PASS"
+  exit
+ elif [ "${KEYALIAS}" = "" ]; then
+  echo "UNDEFINED KEYALIAS"
+  exit
+ elif [ ${isMod} -ne 0 ]; then
+  echo "Already SSL connector is registered"
+ fi
+
+ sed -i 's|</Service>|<Connector port="8443" protocol="org.apache.coyote.http11.Http11Protocol" maxHttpHeaderSize="8192" \
+  SSLEnabled="true" maxThreads="150" minSpareThreads="25" enableLookups="false" disableUploadTimeout="true" acceptCount="100" \
+  scheme="https" secure="true" clientAuth="false" sslProtocol="TLS" useBodyEncodingForURI="true" keyAlias="'${KEYALIAS}'" \
+  keystoreFile="'${KEYSTORE_PATH}'" keystorePass="'${KEYSTORE_PASS}'" keystoreType="JKS"/>\n<!--SSLCONNECTOR_INSERT-->\n </Service>|g' \
+  /opt/atlassian/atlassian-confluence-${CONF_VERSION}/conf/server.xml
+  echo "SSL connector is registered"
+else
+ echo "SSL=FALSE"
+fi
+
+/opt/atlassian/atlassian-confluence-${CONF_VERSION}/bin/start-confluence.sh -fg


### PR DESCRIPTION
dockerのENVで下記のSSLパラメータを指定すると、SSL接続待ち受けコネクタを追加するようにしました。
・SSL ： SSL接続をしたいときはTRUE　したくないときはFALSE、もしくは定義なし
・KEYALIAS ： キーのエイリアス
・KEYSTORE_PATH ： キーストアのパス
・KEYSTORE_PASS ： キーストアのパスワード
